### PR TITLE
Use updated_at for time message was edited

### DIFF
--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -9,7 +9,7 @@
     </div>
     <% if message.edited? %>
       <div class='col'>
-        <span class='fw-light fs-7'>edited <%= local_time message.created_at, format: :short %></span>
+        <span class='fw-light fs-7'>edited <%= local_time message.updated_at, format: :short %></span>
       </div>
     <% end %>
     <div class='col invisible' data-message-target='actions'>


### PR DESCRIPTION
The time a message was edited should use `updated_at` instead of `created_at`. This PR fixes that typo.